### PR TITLE
fixed some naming issues that were caused by late changes yesterday

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -12,9 +12,7 @@ class ListingsController < ApplicationController
   end
 
   def create
-    raise
     @listing = Listing.new(listing_params)
-
     respond_to do |format|
       if @listing.save
         format.html { redirect_to @listing, notice: 'listing was successfully created.' }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
   def home
+    skip_before_action :authenticate_user!, only: :home, :new, :create
   end
 end

--- a/app/views/listings/_form.html.erb
+++ b/app/views/listings/_form.html.erb
@@ -6,7 +6,7 @@
     <%= f.input :name %>
     <%= f.input :address %>
     <%= f.input :price %>
-    <%= f.input :type %>
+    <%= f.input :listing_type %>
     <%= f.input :capacity %>
   </div>
 


### PR DESCRIPTION
Yesterday we changed "type" to "listing_type" as type is a reserve keyword and caused issues. Didn't fix it in the form for example